### PR TITLE
Fix proxy headers

### DIFF
--- a/bemani/utils/proxy.py
+++ b/bemani/utils/proxy.py
@@ -166,13 +166,14 @@ def receive_request(path: str) -> Response:
 
     # Make request to foreign service, using the same parameters
     prep_req = requests.Request(
-		'POST',
-		url=f'http://{remote_host}:{remote_port}{actual_path}',
-		headers=headers,
-		data=req_binary,
+        'POST',
+        url=f'http://{remote_host}:{remote_port}{actual_path}',
+        headers=headers,
+        data=req_binary,
     ).prepare()
-	
-	r = sess.send(prep_req)
+
+    sess = requests.Session()
+    r = sess.send(prep_req)
 
     if r.status_code != 200:
         # Failed on remote side


### PR DESCRIPTION
Proxy wasn't working for me because the headers had default values from the `requests` library, so I fixed it by using a `PreparedRequest`