### PR TITLE
iidx: Fix logic for saving miss count

### DIFF
--- a/bemani/backend/iidx/base.py
+++ b/bemani/backend/iidx/base.py
@@ -349,10 +349,11 @@ class IIDXBase(CoreHandler, CardManagerHandler, PASELIHandler, Base):
             # If it is a new score, create a new dictionary to add to
             scoredata = ValidatedDict({
                 'clear_status': clear_status,
-                'miss_count': miss_count,
                 'pgreats': pgreats,
                 'greats': greats,
             })
+            if miss_count != -1:
+                scoredata.replace_int('miss_count', miss_count)
             if ghost is not None:
                 scoredata['ghost'] = ghost
             raised = True
@@ -364,8 +365,12 @@ class IIDXBase(CoreHandler, CardManagerHandler, PASELIHandler, Base):
             ex_score = max(ex_score, oldscore.points)
             scoredata = oldscore.data
             scoredata.replace_int('clear_status', max(scoredata.get_int('clear_status'), clear_status))
+            if miss_count != -1:
+                if scoredata.get_int('miss_count', -1) == -1:
+                    scoredata.replace_int('miss_count', miss_count)
+                else:
+                    scoredata.replace_int('miss_count', min(scoredata.get_int('miss_count'), miss_count))
             if raised:
-                scoredata.replace_int('miss_count', miss_count)
                 scoredata.replace_int('pgreats', pgreats)
                 scoredata.replace_int('greats', greats)
                 if ghost is not None:

--- a/bemani/frontend/iidx/iidx.py
+++ b/bemani/frontend/iidx/iidx.py
@@ -216,7 +216,7 @@ class IIDXFrontend(FrontendBase):
 
     def format_score(self, userid: UserID, score: Score) -> Dict[str, Any]:
         formatted_score = super().format_score(userid, score)
-        formatted_score['miss_count'] = score.data.get_int('miss_count')
+        formatted_score['miss_count'] = score.data.get_int('miss_count', -1)
         formatted_score['lamp'] = score.data.get_int('clear_status')
         formatted_score['status'] = {
             IIDXBase.CLEAR_STATUS_NO_PLAY: 'NO PLAY',
@@ -232,7 +232,7 @@ class IIDXFrontend(FrontendBase):
 
     def format_top_score(self, userid: UserID, score: Score) -> Dict[str, Any]:
         formatted_score = super().format_score(userid, score)
-        formatted_score['miss_count'] = score.data.get_int('miss_count')
+        formatted_score['miss_count'] = score.data.get_int('miss_count', -1)
         formatted_score['lamp'] = score.data.get_int('clear_status')
         formatted_score['ghost'] = [x for x in (score.data.get_bytes('ghost') or b'')]
         formatted_score['status'] = {
@@ -249,7 +249,7 @@ class IIDXFrontend(FrontendBase):
 
     def format_attempt(self, userid: UserID, attempt: Attempt) -> Dict[str, Any]:
         formatted_attempt = super().format_attempt(userid, attempt)
-        formatted_attempt['miss_count'] = attempt.data.get_int('miss_count')
+        formatted_attempt['miss_count'] = attempt.data.get_int('miss_count', -1)
         formatted_attempt['status'] = {
             IIDXBase.CLEAR_STATUS_NO_PLAY: 'NO PLAY',
             IIDXBase.CLEAR_STATUS_FAILED: 'FAILED',


### PR DESCRIPTION
It was recently brought to my attention that there's a logic error in saving miss_count. The current logic misses the edge case of failing to improve score but still lowering the miss_count. This new logic fixes this issue by rejecting -1 entirely.