### PR TITLE
Implement basic backend cache

### DIFF
--- a/bemani/backend/jubeat/base.py
+++ b/bemani/backend/jubeat/base.py
@@ -64,7 +64,7 @@ class JubeatBase(CoreHandler, CardManagerHandler, PASELIHandler, Base):
         """
         return Node.void('gametop')
 
-    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score]) -> Node:
+    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score], mdata_ver: Optional[int]) -> Node:
         """
         Base handler for a score list. Given a userid, profile and a score list,
         return a Node representing a score list. Should be overridden.
@@ -133,7 +133,7 @@ class JubeatBase(CoreHandler, CardManagerHandler, PASELIHandler, Base):
 
         return self.format_profile(userid, profile)
 
-    def get_scores_by_extid(self, extid: Optional[int]) -> Optional[Node]:
+    def get_scores_by_extid(self, extid: Optional[int], mdata_ver: Optional[int]) -> Optional[Node]:
         """
         Given an ExtID, return a formatted score node. Similar rationale to
         get_profile_by_refid.
@@ -148,7 +148,7 @@ class JubeatBase(CoreHandler, CardManagerHandler, PASELIHandler, Base):
         profile = self.get_profile(userid)
         if profile is None:
             return None
-        return self.format_scores(userid, profile, scores)
+        return self.format_scores(userid, profile, scores, mdata_ver)
 
     def update_score(
         self,

--- a/bemani/backend/jubeat/clan.py
+++ b/bemani/backend/jubeat/clan.py
@@ -1038,18 +1038,8 @@ class JubeatClan(
         data = request.child('data')
         player = data.child('player')
         extid = player.child_value('jid')
-        mdata_ver = player.child_value('mdata_ver')  # Game requests mdata 3 times per profile for some reason
-        if mdata_ver != 1:
-            root = Node.void('gametop')
-            datanode = Node.void('data')
-            root.add_child(datanode)
-            player = Node.void('player')
-            datanode.add_child(player)
-            player.add_child(Node.s32('jid', extid))
-            playdata = Node.void('mdata_list')
-            player.add_child(playdata)
-            return root
-        root = self.get_scores_by_extid(extid)
+        mdata_ver = player.child_value('mdata_ver')
+        root = self.get_scores_by_extid(extid, mdata_ver)
         if root is None:
             root = Node.void('gametop')
             root.set_attribute('status', str(Status.NO_PROFILE))
@@ -1103,8 +1093,14 @@ class JubeatClan(
 
         return Node.void('gameend')
 
-    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score]) -> Node:
-
+    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score], mdata_ver: Optional[int]) -> Node:
+        if mdata_ver is None:
+            mdata_ver = 1
+        min_music_id, max_music_id = {
+            1: (0, 60000000),
+            2: (60000000, 90009999),
+            3: (90009999, 1000000000),
+        }.get(mdata_ver)
         root = Node.void('gametop')
         datanode = Node.void('data')
         root.add_child(datanode)
@@ -1164,6 +1160,8 @@ class JubeatClan(
                 music.replace_dict(str(score.id), data)
 
         for scoreid in music:
+            if int(scoreid) >= max_music_id or int(scoreid) <= min_music_id:
+                continue
             scoredata = music.get_dict(scoreid)
             musicdata = Node.void('musicdata')
             playdata.add_child(musicdata)

--- a/bemani/backend/jubeat/prop.py
+++ b/bemani/backend/jubeat/prop.py
@@ -536,17 +536,7 @@ class JubeatProp(
         player = data.child('player')
         extid = player.child_value('jid')
         mdata_ver = player.child_value('mdata_ver')  # Game requests mdata 3 times per profile for some reason
-        if mdata_ver != 1:
-            root = Node.void('gametop')
-            datanode = Node.void('data')
-            root.add_child(datanode)
-            player = Node.void('player')
-            datanode.add_child(player)
-            player.add_child(Node.s32('jid', extid))
-            playdata = Node.void('mdata_list')
-            player.add_child(playdata)
-            return root
-        root = self.get_scores_by_extid(extid)
+        root = self.get_scores_by_extid(extid, mdata_ver)
         if root is None:
             root = Node.void('gametop')
             root.set_attribute('status', str(Status.NO_PROFILE))
@@ -1341,8 +1331,14 @@ class JubeatProp(
 
         return newprofile
 
-    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score]) -> Node:
-
+    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score], mdata_ver: Optional[int]) -> Node:
+        if mdata_ver is None:
+            mdata_ver = 1
+        min_music_id, max_music_id = {
+            1: (0, 60000000),
+            2: (60000000, 90009999),
+            3: (90009999, 1000000000),
+        }.get(mdata_ver)
         root = Node.void('gametop')
         datanode = Node.void('data')
         root.add_child(datanode)
@@ -1395,6 +1391,8 @@ class JubeatProp(
             music.replace_dict(str(score.id), data)
 
         for scoreid in music:
+            if int(scoreid) >= max_music_id or int(scoreid) <= min_music_id:
+                continue
             scoredata = music[scoreid]
             musicdata = Node.void('musicdata')
             playdata.add_child(musicdata)

--- a/bemani/backend/jubeat/qubell.py
+++ b/bemani/backend/jubeat/qubell.py
@@ -432,18 +432,8 @@ class JubeatQubell(
         data = request.child('data')
         player = data.child('player')
         extid = player.child_value('jid')
-        mdata_ver = player.child_value('mdata_ver')  # Game requests mdata 3 times per profile for some reason
-        if mdata_ver != 1:
-            root = Node.void('gametop')
-            datanode = Node.void('data')
-            root.add_child(datanode)
-            player = Node.void('player')
-            datanode.add_child(player)
-            player.add_child(Node.s32('jid', extid))
-            playdata = Node.void('mdata_list')
-            player.add_child(playdata)
-            return root
-        root = self.get_scores_by_extid(extid)
+        mdata_ver = player.child_value('mdata_ver')
+        root = self.get_scores_by_extid(extid, mdata_ver)
         if root is None:
             root = Node.void('gametop')
             root.set_attribute('status', str(Status.NO_PROFILE))
@@ -842,8 +832,14 @@ class JubeatQubell(
 
         return root
 
-    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score]) -> Node:
-
+    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score], mdata_ver: Optional[int]) -> Node:
+        if mdata_ver is None:
+            mdata_ver = 1
+        min_music_id, max_music_id = {
+            1: (0, 60000000),
+            2: (60000000, 90009999),
+            3: (90009999, 1000000000),
+        }.get(mdata_ver)
         root = Node.void('gametop')
         datanode = Node.void('data')
         root.add_child(datanode)
@@ -896,6 +892,8 @@ class JubeatQubell(
             music.replace_dict(str(score.id), data)
 
         for scoreid in music:
+            if int(scoreid) >= max_music_id or int(scoreid) <= min_music_id:
+                continue
             scoredata = music[scoreid]
             musicdata = Node.void('musicdata')
             playdata.add_child(musicdata)

--- a/bemani/backend/jubeat/saucerfulfill.py
+++ b/bemani/backend/jubeat/saucerfulfill.py
@@ -267,18 +267,7 @@ class JubeatSaucerFulfill(
         player = data.child('player')
         extid = player.child_value('jid')
         mdata_ver = player.child_value('mdata_ver')  # Game requests mdata 3 times per profile for some reason
-        if mdata_ver != 1:
-            root = Node.void('gametop')
-            datanode = Node.void('data')
-            root.add_child(datanode)
-            player = Node.void('player')
-            datanode.add_child(player)
-            player.add_child(Node.s32('jid', extid))
-            playdata = Node.void('playdata')
-            player.add_child(playdata)
-            playdata.set_attribute('count', '0')
-            return root
-        root = self.get_scores_by_extid(extid)
+        root = self.get_scores_by_extid(extid, mdata_ver)
         if root is None:
             root = Node.void('gametop')
             root.set_attribute('status', str(Status.NO_PROFILE))
@@ -288,7 +277,8 @@ class JubeatSaucerFulfill(
         data = request.child('data')
         player = data.child('player')
         extid = player.child_value('rival')
-        root = self.get_scores_by_extid(extid)
+        mdata_ver = player.child_value('mdata_ver')
+        root = self.get_scores_by_extid(extid, mdata_ver)
         if root is None:
             root = Node.void('gametop')
             root.set_attribute('status', str(Status.NO_PROFILE))
@@ -755,8 +745,14 @@ class JubeatSaucerFulfill(
 
         return newprofile
 
-    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score]) -> Node:
-
+    def format_scores(self, userid: UserID, profile: Profile, scores: List[Score], mdata_ver: Optional[int]) -> Node:
+        if mdata_ver is None:
+            mdata_ver = 1
+        min_music_id, max_music_id = {
+            1: (0, 60000000),
+            2: (60000000, 90009999),
+            3: (90009999, 1000000000),
+        }.get(mdata_ver)
         root = Node.void('gametop')
         datanode = Node.void('data')
         root.add_child(datanode)
@@ -810,6 +806,8 @@ class JubeatSaucerFulfill(
             music.replace_dict(str(score.id), data)
 
         for scoreid in music:
+            if int(scoreid) >= max_music_id or int(scoreid) <= min_music_id:
+                continue
             scoredata = music[scoreid]
             musicdata = Node.void('musicdata')
             playdata.add_child(musicdata)

--- a/bemani/data/__init__.py
+++ b/bemani/data/__init__.py
@@ -1,4 +1,5 @@
 from bemani.data.config import Config
+from bemani.data.cache import cached
 from bemani.data.data import Data, DBCreateException
 from bemani.data.exceptions import ScoreSaveException
 from bemani.data.types import User, Achievement, Machine, Arcade, Score, Attempt, News, Link, Song, Event, Server, Client, UserID, ArcadeID
@@ -27,4 +28,5 @@ __all__ = [
     "ArcadeID",
     "RemoteUser",
     "Triggers",
+    "cached",
 ]

--- a/bemani/data/api/music.py
+++ b/bemani/data/api/music.py
@@ -7,6 +7,7 @@ from bemani.data.mysql.user import UserData
 from bemani.data.mysql.music import MusicData
 from bemani.data.remoteuser import RemoteUser
 from bemani.data.types import UserID, Score, Song
+from bemani.data import cached
 
 
 class GlobalMusicData(BaseGlobalData):
@@ -500,6 +501,7 @@ class GlobalMusicData(BaseGlobalData):
 
         return topscore
 
+    @cached(lifetime=5)
     def get_scores(
         self,
         game: GameConstants,
@@ -729,6 +731,7 @@ class GlobalMusicData(BaseGlobalData):
 
         return finalscores
 
+    @cached(lifetime=30)
     def get_all_records(
         self,
         game: GameConstants,

--- a/bemani/data/cache.py
+++ b/bemani/data/cache.py
@@ -1,0 +1,53 @@
+from typing import Any, Callable
+from functools import wraps
+import hashlib
+import pickle
+# Make memcache optional
+try:
+    import pylibmc  # type: ignore
+    has_mc = True
+except ModuleNotFoundError:
+    has_mc = False
+
+
+def cached(lifetime: int=10, extra_key: Any=None) -> Callable:
+    def _cached(func: Callable) -> Callable:
+        if has_mc:
+            memcache = pylibmc.Client(["127.0.0.1"], binary=True)
+            memcache.behaviors = {"tcp_nodelay": True, "ketama": True}
+        else:
+            memcache = None
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if memcache is None:
+                return func(*args, **kwargs)
+
+            if lifetime is not None:
+
+                # Hash function args
+                items = kwargs.items()
+                hashable_args = (args[1:], sorted(list(items)))
+
+                args_key = hashlib.md5(pickle.dumps(hashable_args)).hexdigest()
+
+                # Generate unique cache key
+                cache_key = f'{func.__module__}-{func.__name__}-{args_key}-{extra_key() if hasattr(extra_key, "__call__") else extra_key}'
+
+                # Return cached version if allowed and available
+                result = memcache.get(cache_key)
+                if result is not None:
+                    return result
+
+            # Generate output
+            result = func(*args, **kwargs)
+
+            # Cache output if allowed
+            if lifetime is not None and result is not None:
+                memcache.set(cache_key, result, lifetime)
+
+            return result
+
+        return wrapper
+
+    return _cached

--- a/bemani/data/mysql/music.py
+++ b/bemani/data/mysql/music.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects.mysql import BIGINT as BigInteger  # type: ignore
 from typing import Optional, Dict, List, Tuple, Any
 
 from bemani.common import GameConstants, Time
+from bemani.data import cached
 from bemani.data.exceptions import ScoreSaveException
 from bemani.data.mysql.base import BaseData, metadata
 from bemani.data.types import Score, Attempt, Song, UserID
@@ -691,6 +692,7 @@ class MusicData(BaseData):
 
         return scores
 
+    @cached(lifetime=30)
     def get_all_records(
         self,
         game: GameConstants,


### PR DESCRIPTION
Also paginate jubeat's get_mdata request. For now, this change is very experimental and could probably use some sort of testing. This is not ready to merge but review would be appreciated. The `cached` decorator is based heavily off the one from here: https://stackoverflow.com/a/16723844
If merged this will close #41 since paginating the database lookup will no longer be required if we can just do one big lookup first. I'm hesitant to add the new lib (pylibmc) to requirements.txt since this should likely be an optional thing to run since it also requires having memcached installed and running.
