### PR TITLE
Adds read.py support for M39:J:A:A:2019062500

### DIFF
--- a/bemani/utils/read.py
+++ b/bemani/utils/read.py
@@ -1596,6 +1596,79 @@ class ImportPopn(ImportBase):
                 )
             )
 
+            # Based on M39:J:A:A:2019062500
+            configurations.append(
+                PopnScrapeConfiguration(
+                    version="M39:J:A:A:2019062500",
+                    # Normal offset for music DB, size
+                    offset=0x2B8C20,
+                    step=172,
+                    length=1795,
+                    # Offset and step of file DB
+                    file_offset=0x2A9AF8,
+                    file_step=32,
+                    # Standard lookups
+                    genre_offset=0,
+                    title_offset=1,
+                    artist_offset=2,
+                    comment_offset=3,
+                    english_title_offset=4,
+                    english_artist_offset=5,
+                    extended_genre_offset=None,
+                    charts_offset=8,
+                    folder_offset=9,
+                    # Offsets for normal chart difficulties
+                    easy_offset=12,
+                    normal_offset=13,
+                    hyper_offset=14,
+                    ex_offset=15,
+                    # Offsets for battle chart difficulties
+                    battle_normal_offset=16,
+                    battle_hyper_offset=17,
+                    # Offsets into which offset to seek to for file lookups
+                    easy_file_offset=18,
+                    normal_file_offset=19,
+                    hyper_file_offset=20,
+                    ex_file_offset=21,
+                    battle_normal_file_offset=22,
+                    battle_hyper_file_offset=23,
+                    packedfmt=(
+                        "<"
+                        "I"  # Genre
+                        "I"  # Title
+                        "I"  # Artist
+                        "I"  # Comment
+                        "I"  # English Title
+                        "I"  # English Artist
+                        "H"  # ??
+                        "H"  # ??
+                        "I"  # Available charts mask
+                        "I"  # Folder
+                        "I"  # Event unlocks?
+                        "I"  # Event unlocks?
+                        "B"  # Easy difficulty
+                        "B"  # Normal difficulty
+                        "B"  # Hyper difficulty
+                        "B"  # EX difficulty
+                        "B"  # Battle normal difficulty
+                        "B"  # Battle hyper difficulty
+                        "xx"  # Unknown pointer
+                        "H"  # Easy chart pointer
+                        "H"  # Normal chart pointer
+                        "H"  # Hyper chart pointer
+                        "H"  # EX chart pointer
+                        "H"  # Battle normal pointer
+                        "H"  # Battle hyper pointer
+                        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                    ),
+                    # Offsets into file DB for finding file and folder.
+                    file_folder_offset=0,
+                    file_name_offset=1,
+                    filefmt="<" "I" "I" "I" "I" "I" "I" "I" "I",  # Folder  # Filename
+                    available_charts=available_charts,
+                )
+            )
+
             # Based on M39:J:A:A:2020092800
             configurations.append(
                 PopnScrapeConfiguration(
@@ -2519,7 +2592,7 @@ class ImportJubeat(ImportBase):
         if self.version is not None:
             raise CLIException("Unsupported Jubeat version, expected one of the following: all")
 
-        with open(tsvfile, newline="") as tsvhandle:
+        with open(tsvfile, newline="", encoding="utf-8") as tsvhandle:
             jubeatreader = csv.reader(tsvhandle, delimiter="\t", quotechar='"')
             for row in jubeatreader:
                 songid = int(row[0])
@@ -3246,7 +3319,7 @@ class ImportIIDX(ImportBase):
         if self.version is not None:
             raise CLIException("Unsupported IIDX version, expected one of the following: all")
 
-        with open(tsvfile, newline="") as tsvhandle:
+        with open(tsvfile, newline="", encoding="utf-8") as tsvhandle:
             iidxreader = csv.reader(tsvhandle, delimiter="\t", quotechar='"')
             for row in iidxreader:
                 songid = int(row[0])


### PR DESCRIPTION
Adds a missing pop'n music peace build. 
This also forces utf-8 in IIDX and jubeat read (Windows quirk) to fix that issue that keeps popping up.