### PR TITLE
Fix requirements.txt for 3.6 and 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ types-Werkzeug
 types-Flask
 types-freezegun
 flake8
-typed-ast
+typed-ast ; python_version < "3.8"
 freezegun
 pyreact @ git+https://github.com/DragonMinded/react-python@main
 Flask-Caching
@@ -25,7 +25,8 @@ blinker
 pycryptodome
 jaconv
 pefile
-pillow
+pillow<=8.3.2 ; python_version < "3.7"
+pillow>8.3.2 ; python_version >= "3.7"
 discord_webhook
 iced-x86
 python-memcached

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ types-Werkzeug
 types-Flask
 types-freezegun
 flake8
-typed-ast ; python_version < "3.8"
+typed-ast ; python_version < "3.13"
 freezegun
 pyreact @ git+https://github.com/DragonMinded/react-python@main
 Flask-Caching
@@ -25,8 +25,7 @@ blinker
 pycryptodome
 jaconv
 pefile
-pillow<=8.3.2 ; python_version < "3.7"
-pillow>8.3.2 ; python_version >= "3.7"
+pillow
 discord_webhook
 iced-x86
 python-memcached


### PR DESCRIPTION
Adjusts requirements.txt so it no longer attempts to install a version of pillow that's too new for 3.6, and no longer attempts to install typed-ast which fails (and is unnecessary) on 3.13. Ran tests on 3.13 after this and they passed